### PR TITLE
Check for term sequence when running openCloseImport

### DIFF
--- a/src/importOpenCloseCSV.bat
+++ b/src/importOpenCloseCSV.bat
@@ -26,7 +26,7 @@ IF "%6"=="" (
 
 IF "%port%"=="" SET port=5432
 
-psql -h %hostname% -p %port% -d %database% -U %username% -c "TRUNCATE openCloseStaging;" -c "\COPY openCloseStaging FROM %1 WITH csv HEADER" -c "SELECT openCloseImport(%2, '%3');"
+psql -h %hostname% -p %port% -d %database% -U %username% -c "SELECT gradebook.createOpenCloseStaging();" -c "\COPY pg_temp.openCloseStaging FROM %1 WITH csv HEADER" -c "SELECT gradebook.openCloseImport(%2, '%3');"
 goto end
 
 :argError

--- a/src/openCloseImport.sql
+++ b/src/openCloseImport.sql
@@ -94,7 +94,7 @@ $$
      Location VARCHAR(25),
      Instructor VARCHAR(200)
   );
-$$
+$$ LANGUAGE sql;
 
 
 --Populates Term, Instructor, Course, Course_Section and Section_Instructor from


### PR DESCRIPTION
Updates to ```openCloseImport.sql```:
- The function checkTermSequence() is used to check if the next csv being imported is the next in sequence, i.e. Fall 2016 should be the only csv allowed to import after Summer 2016
- importOpenClose has been updated to work with the ```Season``` table