### PR TITLE
Add Gradebook web server

### DIFF
--- a/src/webapp/gradebookServer.js
+++ b/src/webapp/gradebookServer.js
@@ -98,6 +98,11 @@ app.get('/', function(request, response) {
    response.sendFile('client/index.html', {root: __dirname});
 });
 
+//Serve our homepage when a user goes to the root
+app.get('/index.html', function(request, response) {
+   response.sendFile('client/index.html', {root: __dirname});
+});
+
 //Serve css and js dependencies
 app.get('/css/materialize.min.css', function(request, response) {
 	response.sendFile('client/css/materialize.min.css', {root: __dirname});


### PR DESCRIPTION
This adds an initial version of the Gradebook web server.  The following URL handlers are implemented:
- `/`: Sends `index.html` to the client.  Note we will have to set the correct path for this file.
- `/gradebook/attendance`: Returns a `<table>` containing the attendance matrix for a given section.
- `/gradebook/year`: Returns all the years an instructor has taught sections.
- `/gradebook/season`: Returns all the seasons an instructor taught sections in a given year.
- `/gradebook/course`: Returns all the course an instructor taught in a given term (year + season).
- `/gradebook/section`: Returns all the sections of a given course in a given term an instructor taught.   