### PR TITLE
Web Server /login and REST name updates

### DIFF
--- a/src/webapp/gradebookServer.js
+++ b/src/webapp/gradebookServer.js
@@ -51,11 +51,11 @@ supplied parameters.
 */
 function createConnectionParams(user, database, password, host, port) {
    var config = {
-      user: user,
-      database: database,
-      password: password,
-      host: host,
-      port: port
+      user: user.trim(),
+      database: database.trim(),
+      password: password.trim(),
+      host: host.trim(),
+      port: port.trim()
    };
    return config;
 }
@@ -127,7 +127,7 @@ app.get('/login', function(request, response) {
       passwordText, request.query.host, request.query.port);
 
    //Get the params from the url
-   var instructorEmail = request.query.instructoremail;
+   var instructorEmail = request.query.instructoremail.trim();
 
    //Set the query text
    var queryText = 'SELECT * FROM gradebook.getInstructor($1);';


### PR DESCRIPTION
This branch addresses two of the web server items for M1:
REST call names:
- Most REST call names have been made plural
- `/attendance` and `/login` have been not been changed

`/login` call:
- Takes  the standard database connection parameters and one additional parameter called `instructoremail`
- If an instructor with the matching email exists, it returns the matching row from the instructor table in the form:
```
{
  "instructor":
  {
    "id": <id>
    "fname": "<fname>"
    "mname": "<mname>"
    "lname": "<lname>"
    "department": "<dept>"
  }
}
```
- If no matching instructor is found, a 401 error is returned with the body: "`Login failed - Instructor does not exist`"
- Additional detail has been added to the return bodies of the other 500 errors
