### PR TITLE
Client tasks M1 - Part 1

### DIFF
--- a/src/webapp/client/index.html
+++ b/src/webapp/client/index.html
@@ -15,6 +15,7 @@ ALL ARTIFACTS PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OW
 This HTML page serves as the main access point for an instructor's use of Gradebook.
 Currently, only attendance information is served
 -->
+
 <html>
 	<head>
 	<title>Gradebook</title>
@@ -25,6 +26,7 @@ Currently, only attendance information is served
 	</head>
 	<body>
 	
+	<!--Top of screen banner (navbar) - Includes logo, profile, and tabs-->
 	<nav class="nav-extended">
 		<div class="nav-wrapper">
 			<a href="#" class="brand-logo left" style="margin-left: 1%">Gradebook</a>
@@ -132,7 +134,8 @@ Currently, only attendance information is served
 	</div>
 	
 	<div class="divider"></div>
-	<div id="attendanceData" class="section"></div>
+	<div id="attendanceData" class="section"></div> <!--Populated dynamically-->
+	
 	</div>
 	
 	<div id="grades">
@@ -154,7 +157,8 @@ Currently, only attendance information is served
 	
 	</div>
 	</div>
-  </body>
+	
+	</body>
 
 	<script type="text/javascript" src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
 	<script type="text/javascript" src="js/materialize.min.js"></script>

--- a/src/webapp/client/js/index.js
+++ b/src/webapp/client/js/index.js
@@ -46,7 +46,10 @@ $(document).ready(function() {
 			var email = $('#email').val().trim();
 			if (email != '') {
 				serverLogin(dbInfo, email, function() {
-					$('#profile').css('display', 'inline');
+					//clear login fields
+					$('#email').val('');
+					$('#passwordBox').val('');
+					
 					popYears(dbInfo);
 				});
 			}
@@ -82,8 +85,13 @@ $(document).ready(function() {
 	$('#logout').click(function() {
 		dbInfo = null;
 		instInfo = null;
-		setYears(null);
+		setYears(null); //reset Attendance dropdowns
+		
+		//hide and reset profile
 		$('#profile').css('display', 'none');
+		$('#instName').html('');
+		
+		//show Login tab, hide Roster, Attendance, Grades, and Reports tabs
 		$('#loginTab').css('display', 'inline');
 		$('#rosterTab, #attnTab, #gradesTab, #reportsTab').css('display', 'none');
 		$('ul.tabs').tabs('select_tab', 'login');
@@ -117,18 +125,22 @@ function serverLogin(connInfo, email, callback) {
 		dataType: 'json',
 		data: urlParams ,
 		success: function(result) {
+			//populate dbInfo and instInfo with info from response
 			dbInfo.instructorid = result.instructor.id;
 			instInfo = { fname:result.instructor.fname, 
 			mname:result.instructor.mname, lname:result.instructor.lname,
 			dept:result.instructor.department };
 			
+			//hide Login tab, show Roster, Attendance, Grades, and Reports tabs
 			$('#loginTab').css('display', 'none');
 			$('#rosterTab, #attnTab, #gradesTab, #reportsTab').css('display', 'inline');
 			$('ul.tabs').tabs('select_tab', 'attendance');
 			
+			//populate instructor name and display profile (including logout menu)
 			//Array.prototype.join is used because in JS: '' + null = 'null'
 			var instName = [instInfo.fname, instInfo.mname, instInfo.lname].join(' ');
 			$('#instName').html(instName);
+			$('#profile').css('display', 'inline');
 			
 			callback();
 		},
@@ -281,7 +293,7 @@ function setSections(htmlText) {
 	$('#sectionSelect').prop('disabled', htmlText == null);
 	$('#sectionSelect').material_select(); //reload dropdown
 	
-	resetAttendance(); //reset dependent fields
+	resetAttendance();
 };
 
 function resetAttendance() {


### PR DESCRIPTION
This pull request implements most of the "required" changes that are part of the Web client portion of milestone M1.

Here is a list of the items addressed in this pull request, copied from the [Milestone M1 wiki page](https://github.com/DASSL/Gradebook/wiki/Milestone-M1):

- Set default database name to `Gradebook`
- Change label `Username` to `DB Username`
- Set default DB user name to `GB_WebApp`
- Change login to accept instructor e-mail and a password: together called _login fields_
- When `Login` button is activated, invoke the server url `/login` and pass the e-mail address
- Add a tab `Roster` as the first tab and a tab `About` as the last tab

_See the wiki page for more details about the last three points_

Changes were also made to reflect the latest changes to the Web Server (see Pull Request #42)

The `index.js` file has been refactored, along with some other small changes in preparation for implementing subsequent changes to the web client (the remaining items under milestone M1).

Currently, all interaction with the web client is still performed under the "Attendance" tab, even logging in. This is expected to be changed in the next major pull request to the Web client (in a day or two).