### PR TITLE
Client tasks M1 - Part 2

### DIFF
--- a/src/webapp/client/index.html
+++ b/src/webapp/client/index.html
@@ -183,7 +183,10 @@ Currently, only attendance information is served
 	</li>
 	</ul>
 	
-	<div id="attendanceData" class="section"></div> <!--Populated dynamically-->
+	<br/>
+	<div id="attendanceData" class="col s12" style="overflow-x:auto">
+		<!--Populated dynamically-->
+	</div>
 	
 	</div>
 	

--- a/src/webapp/client/index.html
+++ b/src/webapp/client/index.html
@@ -33,6 +33,11 @@ Currently, only attendance information is served
 		strong {
 			font-weight: bold;
 		}
+		/* Custom CSS for compact table cells */
+		td.compact {
+			padding: 6px 4px;
+			font-size: 13px;
+		}
 	</style>
 	</head>
 	<body>

--- a/src/webapp/client/index.html
+++ b/src/webapp/client/index.html
@@ -29,7 +29,7 @@ Currently, only attendance information is served
 			font-family: sans-serif;
 			font-size: 16px;
 		}
-		/* Default styling is dependent on a specific font */
+		/* Default styling for strong tag is dependent on a specific font */
 		strong {
 			font-weight: bold;
 		}
@@ -78,10 +78,12 @@ Currently, only attendance information is served
 		</div>
 		<div class="row">
 			<div class="input-field col s12 m6 l3">
+				<i class="material-icons prefix">mail</i>
 				<input id="email" type="email"/>
 				<label for="email">Email</label>
 			</div>
 			<div class="input-field col s12 m6 l3">
+				<i class="material-icons prefix">lock</i>
 				<input id="passwordBox" type="password"/>
 				<label for="passwordBox">Password</label>
 			</div>
@@ -243,6 +245,14 @@ Currently, only attendance information is served
 			  Commons License BY-NC-SA 4.0</a>.</p>
 			<p>PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN
 			 RISK.</p>
+	</div>
+	
+	<!--Generic alert used by showAlert() in index.js-->
+	<div id="msg-genericAlert" class="modal">
+		<div id="genericAlertBody" class="modal-content"></div>
+		<div class="modal-footer">
+			<a href="#!" class="modal-action modal-close waves-effect waves-gray btn-flat">OK</a>
+		</div>
 	</div>
 	
 	</div>

--- a/src/webapp/client/index.html
+++ b/src/webapp/client/index.html
@@ -76,11 +76,15 @@ Currently, only attendance information is served
 			</div>
 			<a id="btnLogin" class="waves-effect waves-light btn">Login</a>
 		</div>
-			
-		<div class="row">
-			<h5>DB Info</h5>
+		
+		<div class="divider"></div><br/>
+		
+		<ul id="dbInfoBox" class="collapsible" data-collapsible="expandable"><li>
+		<div class="collapsible-header">
+			<i id="dbInfoArrow" class="material-icons">keyboard_arrow_down</i>DB Info
 		</div>
-		<div class="row">
+		<div class="collapsible-body">
+			<div class="row">
 			<div class="input-field col s12 m6 l3">
 				<input id="host" type="text" value="localhost"/>
 				<label for="host">Host name</label>
@@ -97,8 +101,9 @@ Currently, only attendance information is served
 				<input id="user" type="text" value="GB_WebApp"/>
 				<label for="user">DB Username</label>
 			</div>
-
+			</div>
 		</div>
+		</li></ul>
 	</div>
 	
 	<div id="roster">

--- a/src/webapp/client/index.html
+++ b/src/webapp/client/index.html
@@ -23,6 +23,17 @@ Currently, only attendance information is served
 	<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 	<!--Import Materialize framework - Learn more: http://materializecss.com/-->
 	<link type="text/css" rel="stylesheet" href="css/materialize.min.css"  media="screen,projection"/>
+	<style>
+		/* Materialize attempts to use the Roboto font family by default */
+		html {
+			font-family: sans-serif;
+			font-size: 16px;
+		}
+		/* Default styling is dependent on a specific font */
+		strong {
+			font-weight: bold;
+		}
+	</style>
 	</head>
 	<body>
 	
@@ -178,12 +189,60 @@ Currently, only attendance information is served
 	</div>
 	
 	<div id="about">
-		<p class="center-align">The About page is not yet complete</p>
-		<br/>
-		<h3>Gradebook</h3>
-		<p>Gradebook is an open-source product to provide a simple means for 
-			instructors to record student assessment and attendance.</p>
-		<a href="https://github.com/DASSL/Gradebook">View Gradebook on GitHub.com</a>
+		<h3>About Gradebook</h3>
+		<p>Gradebook is an open-source product for instructors to record student
+		 assessment and attendance. It is developed at the Data Science &amp;
+		 Systems Lab (<a href="https://dassl.github.io">DASSL</a>, read 
+		 <em>dazzle</em>) at the Western Connecticut State University 
+		 (<a href="http://wcsu.edu/">WCSU</a>).</p>
+		<h4>Goals</h4>
+		<p>Gradebook is developed with the following goals:</p>
+		<ol>
+			<li>Provide instructors a free, open, and modern tool to record 
+			 student assessment and attendance</li>
+			<li>Provide instructors a framework to surface, analyze, and visualize
+			 patterns in student performance</li>
+			<li>Use (and demonstrate the use of) modern tools and processes in
+			 software and data engineering</li>
+			<li>Provide Computer Science students a real-life application to
+			 develop and maintain as both curricular and co-curricular activity</li>
+			<li>Provide Computer Science students a framework to experience
+			 first-hand topics such as: web and mobile application development;
+			 RESTful APIs; multi-tenancy; scalability; and cloud-based services.</li>
+		</ol>
+		<h3>Status</h3>
+		<p>Gradebook is still in early stages of development (“alpha stage”).
+		 Much of its external documentation is in the form of README files
+		 contained in various directories within the product repository. The
+		 source code is commented reasonably well. More information about Gradebook,
+		 can be found by visiting its <a href="https://github.com/DASSL/Gradebook">
+		 repository on GitHub</a>.</p>
+		<p><strong>Caution:</strong> Because the product is still in very early
+		 stages of development, it should not be used as a production system in
+		 its current state. There are no guarantees that future development
+		 releases will provide any kind of backward compatibility or portability.</p>
+		<h3>Contributors</h3>
+		<p>Gradebook was conceived by and is designed by 
+		 <a href="http://sites.wcsu.edu/murthys/">Sean Murthy</a>, a member of
+		 the Computer Science faculty at WCSU.</p>
+		<p>The following undergraduate Computer Science students at WCSU
+		 contribute(d) to the development of Gradebook:</p>
+		<ul class="browser-default">
+			<li><a href="https://github.com/bella004">Kyle Bella</a></li>
+			<li><a href="https://github.com/zbhujwala">Zaid Bhujwala</a></li>
+			<li><a href="https://github.com/ZBoylan">Zach Boylan</a></li>
+			<li><a href="https://github.com/afig">Andrew Figueroa</a></li>
+			<li><a href="https://github.com/griffine">Elly Griffin</a></li>
+			<li><a href="https://github.com/srrollo">Steven Rollo</a></li>
+			<li><a href="https://github.com/hunterSchloss">Hunter Schloss</a></li>
+		</ul>
+		<h3>Legal Stuff</h3>
+			<p>© 2017- DASSL. ALL RIGHTS RESERVED.</p>
+			<p>Gradebook is distributed under
+			 <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative
+			  Commons License BY-NC-SA 4.0</a>.</p>
+			<p>PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN
+			 RISK.</p>
 	</div>
 	
 	</div>

--- a/src/webapp/client/index.html
+++ b/src/webapp/client/index.html
@@ -111,7 +111,7 @@ Currently, only attendance information is served
 	</div>
 	
 	<div id="attendance">
-	<div class="row section">
+	<div class="row">
 		<div class="input-field col s12 m6 l3">
 			<select id="yearSelect" disabled="true">
 				<option value="" disabled="true" selected="true">Choose year</option>
@@ -139,6 +139,32 @@ Currently, only attendance information is served
 	</div>
 	
 	<div class="divider"></div>
+	
+	<ul id="attnOptionsBox" class="collapsible" style="display: none" data-collapsible="expandable">
+	<li>
+		<div class="collapsible-header">
+			<i id="optionsArrow" class="material-icons">keyboard_arrow_down</i>Options
+		</div>
+		<div class="collapsible-body">
+			<div class="switch">
+			Display 'P' attendance code
+			<label>
+				<input id="opt-showPresent" type="checkbox">
+				<span class="lever"></span>
+			</label>
+			</div>
+			<br/>
+			<div class="switch">
+			Display compact table
+			<label>
+				<input id="opt-compactTab" type="checkbox">
+				<span class="lever"></span>
+			</label>
+			</div>
+		</div>
+	</li>
+	</ul>
+	
 	<div id="attendanceData" class="section"></div> <!--Populated dynamically-->
 	
 	</div>

--- a/src/webapp/client/index.html
+++ b/src/webapp/client/index.html
@@ -199,13 +199,13 @@ Currently, only attendance information is served
 	</div>
 	
 	<div id="about">
-		<h3>About Gradebook</h3>
+		<h4>About Gradebook</h4>
 		<p>Gradebook is an open-source product for instructors to record student
 		 assessment and attendance. It is developed at the Data Science &amp;
-		 Systems Lab (<a href="https://dassl.github.io">DASSL</a>, read 
-		 <em>dazzle</em>) at the Western Connecticut State University 
-		 (<a href="http://wcsu.edu/">WCSU</a>).</p>
-		<h4>Goals</h4>
+		 Systems Lab (<a href="https://dassl.github.io" target="_blank">DASSL</a>
+		 , read <em>dazzle</em>) at the Western Connecticut State University 
+		 (<a href="http://wcsu.edu/" target="_blank">WCSU</a>).</p>
+		<h5>Goals</h5>
 		<p>Gradebook is developed with the following goals:</p>
 		<ol>
 			<li>Provide instructors a free, open, and modern tool to record 
@@ -220,37 +220,38 @@ Currently, only attendance information is served
 			 first-hand topics such as: web and mobile application development;
 			 RESTful APIs; multi-tenancy; scalability; and cloud-based services.</li>
 		</ol>
-		<h3>Status</h3>
+		<h5>Status</h5>
 		<p>Gradebook is still in early stages of development (“alpha stage”).
 		 Much of its external documentation is in the form of README files
 		 contained in various directories within the product repository. The
-		 source code is commented reasonably well. More information about Gradebook,
-		 can be found by visiting its <a href="https://github.com/DASSL/Gradebook">
-		 repository on GitHub</a>.</p>
+		 source code is commented reasonably well. More information about Gradebook
+		 can be found by visiting its
+		 <a href="https://github.com/DASSL/Gradebook" target="_blank"> repository
+		 on GitHub</a>.</p>
 		<p><strong>Caution:</strong> Because the product is still in very early
 		 stages of development, it should not be used as a production system in
 		 its current state. There are no guarantees that future development
 		 releases will provide any kind of backward compatibility or portability.</p>
-		<h3>Contributors</h3>
+		<h5>Contributors</h5>
 		<p>Gradebook was conceived by and is designed by 
-		 <a href="http://sites.wcsu.edu/murthys/">Sean Murthy</a>, a member of
-		 the Computer Science faculty at WCSU.</p>
+		 <a href="http://sites.wcsu.edu/murthys/" target="_blank">Sean Murthy</a>,
+		 a member of the Computer Science faculty at WCSU.</p>
 		<p>The following undergraduate Computer Science students at WCSU
 		 contribute(d) to the development of Gradebook:</p>
 		<ul class="browser-default">
-			<li><a href="https://github.com/bella004">Kyle Bella</a></li>
-			<li><a href="https://github.com/zbhujwala">Zaid Bhujwala</a></li>
-			<li><a href="https://github.com/ZBoylan">Zach Boylan</a></li>
-			<li><a href="https://github.com/afig">Andrew Figueroa</a></li>
-			<li><a href="https://github.com/griffine">Elly Griffin</a></li>
-			<li><a href="https://github.com/srrollo">Steven Rollo</a></li>
-			<li><a href="https://github.com/hunterSchloss">Hunter Schloss</a></li>
+			<li><a href="https://github.com/bella004" target="_blank">Kyle Bella</a></li>
+			<li><a href="https://github.com/zbhujwala" target="_blank">Zaid Bhujwala</a></li>
+			<li><a href="https://github.com/ZBoylan" target="_blank">Zach Boylan</a></li>
+			<li><a href="https://github.com/afig" target="_blank">Andrew Figueroa</a></li>
+			<li><a href="https://github.com/griffine" target="_blank">Elly Griffin</a></li>
+			<li><a href="https://github.com/srrollo" target="_blank">Steven Rollo</a></li>
+			<li><a href="https://github.com/hunterSchloss" target="_blank">Hunter Schloss</a></li>
 		</ul>
-		<h3>Legal Stuff</h3>
+		<h5>Legal Stuff</h5>
 			<p>© 2017- DASSL. ALL RIGHTS RESERVED.</p>
 			<p>Gradebook is distributed under
-			 <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative
-			  Commons License BY-NC-SA 4.0</a>.</p>
+			 <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank">
+			 Creative Commons License BY-NC-SA 4.0</a>.</p>
 			<p>PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN
 			 RISK.</p>
 	</div>

--- a/src/webapp/client/js/index.js
+++ b/src/webapp/client/js/index.js
@@ -173,6 +173,7 @@ function serverLogin(connInfo, email, callback) {
 			callback();
 		},
 		error: function(result) {
+			//currently does not distinguish between credential and connection errors
 			showAlert('<h5>Could not login</h5><p>Login failed - ensure ' +
 			 'all fields are correct</p>');
 			console.log(result);
@@ -269,7 +270,12 @@ function popAttendance(connInfo, sectionid) {
 			setAttendance(result);
 		},
 		error: function(result) {
-			showAlert('<p>Error while retrieving attendance data</p>');
+			if (result.responseText == '500 - No Attenance Records') {
+				showAlert('<p>No attendance records exist for this section</p>');
+			}
+			else {
+				showAlert('<p>Error while retrieving attendance data</p>');
+			}
 			setAttendance(null);
 			console.log(result);
 		}
@@ -331,18 +337,16 @@ function setAttendance(htmlText) {
 		}
 		else {
 			if (!showPs) {
-				//replace all 'P' fields with a space, add "Present" tooltip
-				htmlText = htmlText.replace(/<td  colspan=1>P<\/td>/g, '<td ' +
-				 'title="Present" colspan=1> </td>');
+				//replace all 'P' fields with a space
+				htmlText = htmlText.replace(/>P<\/td>/g, '> </td>');
 			}
 			if (isCompact) {
 				//add attibutes to <table> tag to use compact framework styling
 				htmlText = '<table class="striped" style="display:block;' +
 				 'margin:auto;overflow-x:auto;line-height:1.1;">' + htmlText.substring(7);
 				 
-				//change default padding values and font size for each table cell
-				htmlText = htmlText.replace(/<td /g, '<td style="padding:6px 4px;' + 
-				 'font-size:13px"');
+				//give all td tags the "compact" class
+				htmlText = htmlText.replace(/<td /g, '<td class="compact" ');
 			}
 			else {
 				//add attibutes to <table> tag to use non-compact framework styling

--- a/src/webapp/client/js/index.js
+++ b/src/webapp/client/js/index.js
@@ -342,16 +342,15 @@ function setAttendance(htmlText) {
 			}
 			if (isCompact) {
 				//add attibutes to <table> tag to use compact framework styling
-				htmlText = '<table class="striped" style="display:block;' +
-				 'margin:auto;overflow-x:auto;line-height:1.1;">' + htmlText.substring(7);
+				htmlText = '<table class="striped" style="line-height:1.1;">' +
+				 htmlText.substring(7);
 				 
 				//give all td tags the "compact" class
 				htmlText = htmlText.replace(/<td /g, '<td class="compact" ');
 			}
 			else {
 				//add attibutes to <table> tag to use non-compact framework styling
-				htmlText = '<table class="striped" style="display:block;' +
-				 'margin:auto;overflow-x:auto">' + htmlText.substring(7);
+				htmlText = '<table class="striped">' + htmlText.substring(7);
 			}
 		}
 		$('#attnOptionsBox').css('display', 'block');

--- a/src/webapp/client/js/index.js
+++ b/src/webapp/client/js/index.js
@@ -59,22 +59,22 @@ $(document).ready(function() {
 	
 	$('#btnLogin').click(function() {
 		dbInfo = getDBFields();
-		if (dbInfo != null) {
-			var email = $('#email').val().trim();
-			if (email != '') {
-				serverLogin(dbInfo, email, function() {
-					//clear login fields and close DB Info box
-					$('#email').val('');
-					$('#passwordBox').val('');
-					$('#dbInfoBox').collapsible('close', 0);
-					$('#dbInfoArrow').html('keyboard_arrow_down');
-					
-					popYears(dbInfo);
-				});
-			}
-			else {
-				alert('One or more fields are empty');
-			}
+		var email = $('#email').val().trim();
+		if (dbInfo != null && email != '') {
+			serverLogin(dbInfo, email, function() {
+				//clear login fields and close DB Info box
+				$('#email').val('');
+				$('#passwordBox').val('');
+				$('#dbInfoBox').collapsible('close', 0);
+				$('#dbInfoArrow').html('keyboard_arrow_down');
+				
+				popYears(dbInfo);
+			});
+		}
+		else {
+			showAlert('<h5>Missing field(s)</h5><p>One or more fields are ' +
+			 'not filled in.</p><p>All fields are required, including those in ' +
+			 'DB Info.</p>');
 		}
 	});
 	
@@ -123,6 +123,11 @@ $(document).ready(function() {
 	});
 });
 
+function showAlert(htmlContent) {
+	$('#genericAlertBody').html(htmlContent);
+	$('#msg-genericAlert').modal('open');
+};
+
 function getDBFields() {
 	var host = $('#host').val().trim();
 	var port = $('#port').val().trim();
@@ -131,7 +136,6 @@ function getDBFields() {
 	var pw =  $('#passwordBox').val().trim();
 	
 	if (host === "" || port === "" || db === "" || uname === "" || pw === "") {
-		alert('One or more fields are empty');
 		return null;
 	}
 	
@@ -169,7 +173,8 @@ function serverLogin(connInfo, email, callback) {
 			callback();
 		},
 		error: function(result) {
-			alert('Login failed - ensure all fields are correct');
+			showAlert('<h5>Could not login</h5><p>Login failed - ensure ' +
+			 'all fields are correct</p>');
 			console.log(result);
 		}
 	});
@@ -188,7 +193,7 @@ function popYears(connInfo) {
 			setYears(years);
 		},
 		error: function(result) {
-			alert('Error while retrieving years - ensure DB info is correct');
+			showAlert('<p>Error while retrieving years</p>');
 			console.log(result);
 		}
 	});
@@ -208,7 +213,7 @@ function popSeasons(connInfo, year) {
 			setSeasons(seasons);
 		},
 		error: function(result) {
-			alert('Error while retrieving seasons');
+			showAlert('<p>Error while retrieving seasons</p>');
 			console.log(result);
 		}
 	});
@@ -228,7 +233,7 @@ function popCourses(connInfo, year, seasonorder) {
 			setCourses(courses);
 		},
 		error: function(result) {
-			alert('Error while retrieving courses');
+			showAlert('<p>Error while retrieving courses</p>');
 			console.log(result);
 		}
 	});
@@ -249,7 +254,7 @@ function popSections(connInfo, year, seasonorder, coursenumber) {
 			setSections(sections);
 		},
 		error: function(result) {
-			alert('Error while retrieving sections');
+			showAlert('<p>Error while retrieving sections</p>');
 			console.log(result);
 		}
 	});
@@ -264,7 +269,7 @@ function popAttendance(connInfo, sectionid) {
 			setAttendance(result);
 		},
 		error: function(result) {
-			alert('Error while retrieving attendance data');
+			showAlert('<p>Error while retrieving attendance data</p>');
 			setAttendance(null);
 			console.log(result);
 		}
@@ -335,8 +340,9 @@ function setAttendance(htmlText) {
 				htmlText = '<table class="striped" style="display:block;' +
 				 'margin:auto;overflow-x:auto;line-height:1.1;">' + htmlText.substring(7);
 				 
-				//change default padding values for each table cell
-				htmlText = htmlText.replace(/<td /g, '<td style="padding:6px 4px"');
+				//change default padding values and font size for each table cell
+				htmlText = htmlText.replace(/<td /g, '<td style="padding:6px 4px;' + 
+				 'font-size:13px"');
 			}
 			else {
 				//add attibutes to <table> tag to use non-compact framework styling

--- a/src/webapp/client/js/index.js
+++ b/src/webapp/client/js/index.js
@@ -39,6 +39,15 @@ Each instance of connInfo as a parameter in a function definition refers to an
 $(document).ready(function() {
 	$('select').material_select(); //load dropdown boxes
 	
+	$('#dbInfoBox').collapsible({
+		onOpen: function() {
+			$('#dbInfoArrow').html('keyboard_arrow_up');
+		},
+		onClose: function() {
+			$('#dbInfoArrow').html('keyboard_arrow_down');
+		}
+	});
+	
 	
 	$('#btnLogin').click(function() {
 		dbInfo = getDBFields();


### PR DESCRIPTION
This PR addresses the remaining M1 tasks in regards to the web client.

Changes:

- DB Info fields are now placed in a collapsible box. Initially, the box is closed, since the default values should suffice in most situations.

- Added options to the attendance table in a collapsible box. Two options are currently available: "Display 'P' attendance code" and "Display compact table". Both options are disabled by default. Changing either option results in the table automatically updating. Currently, at least for M1, `/attendance` is called again whenever one of these options are changed, rather than using the already obtained table.

- Update error messages and display them using [Materialize's modals](http://materializecss.com/modals.html) rather than JavaScript's `alert()`.

- Update About page to one based on latest version of the repository's README.

Non-M1 changes performed:

- Center-align attendance table and fill to container width.

- Add icons to email and password fields.

***

The test instance I have set up has been updated to the latest version of the client and a recent version of the web server ~~(from commit 53eb0e4b408908adecf632bd98e794dccfebd9da)~~. The database that the test instance is using has been setup using the latest version of all three import scripts.

Edit: The web server on the test instance has been updated to the latest version (from commit 41da447fa21bed2e65fa6f3f83ca08b06024a458).