### PR TITLE
Fix attendance import and add README info

### DIFF
--- a/tests/data/Attendance/importAttendance.psql
+++ b/tests/data/Attendance/importAttendance.psql
@@ -68,7 +68,7 @@ $$ LANGUAGE sql;
 
 --Import data from files to staging table and call import function for each section
 \COPY pg_temp.AttendanceStaging FROM '2017SpringCS110-05Attendance.csv' WITH csv HEADER
-SELECT pg_temp.importAttendance(Gradebook.getSectionID(2017, 0, 'CS110', '05'));
+SELECT pg_temp.importAttendance(Gradebook.getSectionID(2017, 0, 'CS110', '5'));
 TRUNCATE pg_temp.AttendanceStaging;
 
 \COPY pg_temp.AttendanceStaging FROM '2017SpringCS110-72Attendance.csv' WITH csv HEADER

--- a/tests/data/README.md
+++ b/tests/data/README.md
@@ -18,7 +18,7 @@ This file describes the contents of the sub-directories of the directory
 
 This directory contains sample CSV-formatted attendance data, along with a
 script for importing this data. It is required to import the sample data from
-the other two sub-directories (`Open Close` and `Roster`) before importing the
+the other two sub-directories (`OpenClose` and `Roster`) before importing the
 sample attendance data.
 
 The data in the CSV files is structured in a manner that simplifies the import

--- a/tests/data/README.md
+++ b/tests/data/README.md
@@ -1,6 +1,6 @@
 README.md - Gradebook
 
-Sean Murthy, Andrew Figueroa
+Sean Murthy, Andrew Figueroa   
 Data Science & Systems Lab (DASSL), Western Connecticut State University (WCSU)
 
 (C) 2017- DASSL. ALL RIGHTS RESERVED.   

--- a/tests/data/README.md
+++ b/tests/data/README.md
@@ -1,6 +1,6 @@
 README.md - Gradebook
 
-Sean Murthy   
+Sean Murthy, Andrew Figueroa
 Data Science & Systems Lab (DASSL), Western Connecticut State University (WCSU)
 
 (C) 2017- DASSL. ALL RIGHTS RESERVED.   
@@ -13,6 +13,31 @@ PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
 
 This file describes the contents of the sub-directories of the directory
 `/tests/data`.
+
+### Directory `Attendance`
+
+This directory contains sample CSV-formatted attendance data, along with a
+script for importing this data. It is required to import the sample data from
+the other two sub-directories (`Open Close` and `Roster`) before importing the
+sample attendance data.
+
+The data in the CSV files is structured in a manner that simplifies the import
+procedure and the creation of additional test data. However, this structure is
+likely to differ from common structures for attendance information. The current
+structure was obtained by "un-pivoting" an existing set of sample data.
+
+The import script, `importAttendance.psql`, is designed to import the three
+files containing the sample data, but is not intended to import actual
+attendance data.
+
+The filename of each CSV file in `Attendance` encodes the year, season, course,
+and section that the file's data corresponds to. Each filename corresponds with
+sample data in the `Roster` directory.
+
+Similar to the sample roster data, the content of the sample data is based off
+of real attendance information, but have had all connections to real attendance
+data removed. See the description of the `Roster` directory for more information
+and warnings.
 
 ### Directory `OpenClose`
 


### PR DESCRIPTION
This PR adds information about the `Attendance` directory to the `README.md` file located in `/tests/data`. It also implements a fix for issue #58.

Currently, the information about the `Attendance` has been added to the README indicated above. It might be worth considering having another README in the `/Attendance` directory, rather than having all information in the above mentioned README.

***

I have just noticed a small issue where a directory is referred to as `Open Close` rather than `OpenClose`. I will fix that in the next commit.