### PR TITLE
Add server preparation and improve DB preparation

### DIFF
--- a/src/db/README.md
+++ b/src/db/README.md
@@ -13,20 +13,80 @@ PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
 
 ## Overview
 
-This file describes the procedure to prepare the database for an installation
-of Gradebook.
+This file describes the install the data layer of the Gradebook application.
 
-Steps to prepare the database:
-1. Create a new database using a Postgres client such as [`psql`](https://www.postgresql.org/docs/9.6/static/app-psql.html)
-or [`createdb`](https://www.postgresql.org/docs/9.6/static/app-createdb.html)
-2. Run the script `prepareDB.psql` in the context of the newly created database
+Installing the data layer involves three simple steps:
+1. Prepare the database server
+2. Create a database
+3. Prepare the database
 
-## Script `prepareDB.psql`
+The installation process involves running SQL scripts (files with `.sql`
+extension) and PSQL scripts (files with `.psql` extension). SQL scripts may be
+run using any Postgres client such as [`psql`](https://www.postgresql.org/docs/9.6/static/app-psql.html),
+but PSQL scripts must be run using `psql`.
 
-The script `prepareDB.psql` invokes the following scripts to create schema,
-table, function, and other kinds of database objects the Gradebook
-application uses.
+__All scripts should be run by a user with superuser privileges__.
 
+The following alternative means are possible to run either kind of script using
+`psql`:
+
+1. Start `psql` with its usual parameters along with the `-f` command line switch
+and the path to the script file. For example:
+
+      `psql [usual psql parameters] -f [scriptFilePath]`
+
+2. Start `psql` with its usual parameters and once inside the interactive shell,
+use the `\i` meta-command to execute the script
+
+## Preparing the server
+
+Run the SQL script `prepareServer.sql` to prepare the server. This script should
+be the first to run, before creating any database for use with Gradebook.
+
+This script defines application-specific role `gradebook` and user `gb_webapp`.
+The user is given a default initial password (see the script), and it is highly
+recommended that the default password be changed (using a secure Postgres client
+such as `psql`).
+
+
+## Create a database
+
+Create a new database using the `CREATE DATABASE` statement using any Postgres
+client or using the [`createdb`](https://www.postgresql.org/docs/9.6/static/app-createdb.html)
+client.
+
+The database may be named anything and any number of databases may be created.
+However, the role `gradebook` should be set as the owner of each database.
+
+(Multiple Gradebook databases may be used on the same server for multi-tenancy,
+that is one database per school. Also, multiple databases may be needed for
+development and testing purposes.)
+
+The following examples show alternative means to create a database named
+`GB_Data`:
+
+1. Run the following SQL query using any Postgres client:
+
+      ```sql
+      CREATE DATABASE GB_DATA WITH OWNER gradebook;
+      ```
+
+2. Run the following command at a terminal:
+
+      `createdb [connection parameters] -O gradebook GB_Data`
+
+
+## Prepare the database
+
+Run the PSQL script `prepareDB.psql` in the context of each database where
+Gradebook data is to be stored. This script should be run immediately after
+creating the database while the database is still empty.
+
+This script invokes the following SQL scripts to set permissions and to create
+schema, table, function, and other kinds of objects the Gradebook application
+uses.
+
+- `initializeDB.sql`
 - `createTables.sql`
 - `addReferenceData.sql`
 - `addSeasonMgmt.sql`
@@ -34,18 +94,6 @@ application uses.
 - `addAttendanceMgmt.sql`
 - `addInstructorMgmt.sql`
 
-The `.psql` script and the scripts it invokes should all be in the same
-directory, and it must be run using `psql` (due to the use of `psql`
+The PSQL script and the SQL scripts it invokes should all be in the same
+directory. The PSQL script must be run using `psql` (due to the use of `psql`
 meta-commands).
-
-## Running `prepareDB.psql`
-
-Use one of the following means to run the script:
-
-1. Start `psql` with its usual parameters along with the `-f` command line switch
-and the path to the script file. For example:   
-
-      `psql [usual psql parameters] -f prepareDB.psql`
-
-2. Start `psql` with its usual parameters and once inside the interactive shell,
-use the `\i` meta-command to execute the script

--- a/src/db/README.md
+++ b/src/db/README.md
@@ -13,7 +13,10 @@ PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
 
 ## Overview
 
-This file describes the install the data layer of the Gradebook application.
+This file describes the process of installing the data layer of the Gradebook
+application and verifying the installation.
+
+## Installation
 
 Installing the data layer involves three simple steps:
 1. Prepare the database server
@@ -25,7 +28,8 @@ extension) and PSQL scripts (files with `.psql` extension). SQL scripts may be
 run using any Postgres client such as [`psql`](https://www.postgresql.org/docs/9.6/static/app-psql.html),
 but PSQL scripts must be run using `psql`.
 
-__All scripts should be run by a user with superuser privileges__.
+__All scripts in the installation process hould be run by a user with superuser
+privileges__.
 
 The following alternative means are possible to run either kind of script using
 `psql`:
@@ -38,7 +42,7 @@ and the path to the script file. For example:
 2. Start `psql` with its usual parameters and once inside the interactive shell,
 use the `\i` meta-command to execute the script
 
-## Preparing the server
+### Prepare the server
 
 Run the SQL script `prepareServer.sql` to prepare the server. This script should
 be the first to run, before creating any database for use with Gradebook.
@@ -49,7 +53,7 @@ recommended that the default password be changed (using a secure Postgres client
 such as `psql`).
 
 
-## Create a database
+### Create a database
 
 Create a new database using the `CREATE DATABASE` statement using any Postgres
 client or using the [`createdb`](https://www.postgresql.org/docs/9.6/static/app-createdb.html)
@@ -76,7 +80,7 @@ The following examples show alternative means to create a database named
       `createdb [connection parameters] -O gradebook GB_Data`
 
 
-## Prepare the database
+### Prepare the database
 
 Run the PSQL script `prepareDB.psql` in the context of each database where
 Gradebook data is to be stored. This script should be run immediately after
@@ -97,3 +101,33 @@ uses.
 The PSQL script and the SQL scripts it invokes should all be in the same
 directory. The PSQL script must be run using `psql` (due to the use of `psql`
 meta-commands).
+
+## Verifying installation
+
+After the database is prepared, import some sample data to verify installation.
+All sample data is located under the directory `/tests/data` and is described
+in the README file located in that directory. Most of the scripts to import
+data are under the directory `/src/db` and are described in the README files
+located in those directories.
+
+Perform the following verification steps by connecting to the database as
+the user `gb_webapp`. It is sufficient to complete only the first step shown,
+but it is recommended that all steps be performed in the sequence shown. A
+verification step is considered successful if it completes without any error.
+
+1. Import the course schedule in the file `/tests/data/OpenClose/2015SpringOpenClose.csv`
+
+2. Assign e-mail addresses to instructors: run the script `/tests/data/InstructorEmail/addEmailByInstructorName.sql`
+
+3. Import the roster in the file `/tests/data/Roster/2017SpringCS110-05Roster.csv`
+
+4. Import attendance data: run the script `/tests/data/Attendance/importAttendance.psql`
+
+5. Humanize student data: run the script `/src/db/humanizeStudentData.sql`
+
+6. Run the following query to obtain a CSV version of the attendance data
+imported:
+
+```sql
+SELECT * FROM Gradebook.getAttendance(2017, 'Spring', 'CS110', '5');
+```

--- a/src/db/createTables.sql
+++ b/src/db/createTables.sql
@@ -14,8 +14,11 @@
 --E-mail address management is based on the discussion presented at:
 -- https://gist.github.com/smurthys/feba310d8cc89c4e05bdb797ca0c6cac
 
+--This script should be run after running the script initializeDB.sql
+-- in the normal course of operations, this script should not be run
+-- individually, but instead should be called from the script prepareDB.sql
 
-CREATE SCHEMA IF NOT EXISTS Gradebook;
+--This script assumes a schema named "Gradebook" already exists and is empty
 
 
 CREATE TABLE Gradebook.Course

--- a/src/db/initializeDB.sql
+++ b/src/db/initializeDB.sql
@@ -1,0 +1,126 @@
+--initializeDB.sql - Gradebook
+
+--Andrew Figueroa, Steven Rollo, Sean Murthy
+--Data Science & Systems Lab (DASSL), Western Connecticut State University (WCSU)
+
+--(C) 2017- DASSL. ALL RIGHTS RESERVED.
+--Licensed to others under CC 4.0 BY-SA-NC
+--https://creativecommons.org/licenses/by-nc-sa/4.0/
+
+--PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+
+--This script sets up access controls for Gradebook roles
+-- it also creates a 'Gradebook' schema to store app-specific data and code
+
+--This script should be run once in a database where Gradebook data is to be
+--stored
+-- multiple Gradebook DBs are possible on the same server even in deployment,
+-- because as of now multi-tenancy is possible only through multiple DBs;
+-- multiple DBs may also be needed during development and testing
+
+--This script should be the first to run after creating the database
+-- it should be run while the database is still empty
+
+--This script should be run by a superuser
+
+
+START TRANSACTION;
+
+
+--Suppress messages below WARNING level for the duration of this script
+SET LOCAL client_min_messages TO WARNING;
+
+
+--Make sure current user is superuser
+DO
+$$
+BEGIN
+   IF NOT EXISTS (SELECT * FROM pg_catalog.pg_roles
+                  WHERE rolname = current_user AND rolsuper = TRUE
+                 ) THEN
+      RAISE EXCEPTION 'Insufficient privileges: '
+                      'script must be run by a superuser';
+   END IF;
+END
+$$;
+
+
+--Make sure the expected app-specific roles are already defined:
+-- roles expected: Gradebook, GB_WebApp
+DO
+$$
+DECLARE
+   gradebookRoleCount NUMERIC(1);
+BEGIN
+   SELECT COUNT(*)
+   FROM pg_catalog.pg_roles
+   WHERE rolname IN ('gradebook', 'gb_webapp')
+   INTO gradebookRoleCount;
+
+   IF gradebookRoleCount <> 2 THEN
+      RAISE EXCEPTION
+         'Missing roles: one or more of the expected Gradebook roles '
+         'are not defined';
+   END IF;
+END
+$$;
+
+
+--Grant/revoke appropriate privileges to/from various roles on current database
+DO
+$$
+DECLARE
+   currentDB VARCHAR(128);
+BEGIN
+   currentDB = current_database();
+
+   --deny "public" (all users) permission to do anything with the database
+   -- Postgres grants a few privileges by default to all users
+   EXECUTE format('REVOKE ALL PRIVILEGES ON DATABASE %I FROM PUBLIC', currentDB);
+
+   --give Gradebook role all privileges on the current database
+   EXECUTE format('GRANT ALL PRIVILEGES ON DATABASE %I TO Gradebook', currentDB);
+
+   --let user GB_WebApp connect to the database
+   EXECUTE format('GRANT CONNECT ON DATABASE %I TO GB_WebApp', currentDB);
+END
+$$;
+
+
+--Grant Gradebook to the current user
+-- allows altering privilieges of objects, even after being owned by Gradebook;
+-- the utility of (need for) this permission is unclear, but keeping it for now
+GRANT Gradebook TO current_user;
+
+
+--Remove all privileges from public on objects created in the future in this DB
+-- this alteration applies to all schemas in this DB
+ALTER DEFAULT PRIVILEGES REVOKE ALL PRIVILEGES ON TABLES FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES REVOKE ALL PRIVILEGES ON SEQUENCES FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES REVOKE ALL PRIVILEGES ON FUNCTIONS FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES REVOKE ALL PRIVILEGES ON TYPES FROM PUBLIC;
+
+--Give Gradebook role all privileges on objects created in the future in this DB
+-- this alteration applies to all schemas in this DB
+ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON TABLES TO Gradebook;
+ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON SEQUENCES TO Gradebook;
+ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON FUNCTIONS TO Gradebook;
+ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON TYPES TO Gradebook;
+
+
+--Permit only the Gradebook role to create or use objects the public schema
+REVOKE ALL PRIVILEGES ON SCHEMA public FROM PUBLIC;
+GRANT ALL PRIVILEGES ON SCHEMA public TO  Gradebook;
+
+
+--Create a schema to hold app-specific info and permit only the Gradebook role
+--to create or use objects in that schema
+-- this code might have to be moved to a function if schemas are used to support
+-- multi-tenancy (schema name will be a parameter)
+CREATE SCHEMA IF NOT EXISTS Gradebook;
+REVOKE ALL PRIVILEGES ON SCHEMA Gradebook FROM PUBLIC;
+GRANT ALL PRIVILEGES ON SCHEMA Gradebook TO Gradebook;
+
+
+
+COMMIT;

--- a/src/db/prepareDB.psql
+++ b/src/db/prepareDB.psql
@@ -12,6 +12,8 @@
 --This script invokes other scripts which create schema, table, function, and
 --other kinds of database objects used in the Gradebook application
 
+--This script should be run after running the script prepareServer.sql
+
 --This script should be run in the context of the database expected to hold
 --Gradebook data
 -- the database must already exist and be empty;
@@ -25,6 +27,7 @@
 
 
 \set ON_ERROR_STOP on
+\i initializeDB.sql
 \i createTables.sql
 \i addReferenceData.sql
 \i addSeasonMgmt.sql

--- a/src/db/prepareServer.sql
+++ b/src/db/prepareServer.sql
@@ -1,0 +1,87 @@
+--prepareServer.sql - Gradebook
+
+--Andrew Figueroa, Steven Rollo, Sean Murthy
+--Data Science & Systems Lab (DASSL), Western Connecticut State University (WCSU)
+
+--(C) 2017- DASSL. ALL RIGHTS RESERVED.
+--Licensed to others under CC 4.0 BY-SA-NC
+--https://creativecommons.org/licenses/by-nc-sa/4.0/
+
+--PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+
+--This script creates app-specific roles and users
+-- roles created: Gradebook; users created: GB_WebApp;
+-- makes GB_WebApp a member of the Gradebook role as a temporary measure until
+-- roles and policies are finalized
+
+--This script should be run once on the server where Gradebook data will be
+--stored
+-- it should be the first script to run in the Gradebook installation process;
+-- it should be run before creating a database where Gradebook data is to be
+-- stored
+
+--This script should be run by a superuser
+
+
+START TRANSACTION;
+
+--Suppress messages below WARNING level for the duration of this script
+SET LOCAL client_min_messages TO WARNING;
+
+--Make sure current user is superuser
+DO
+$$
+BEGIN
+   IF NOT EXISTS (SELECT * FROM pg_catalog.pg_roles
+                  WHERE rolname = current_user AND rolsuper = TRUE
+                 ) THEN
+      RAISE EXCEPTION 'Insufficient privileges: '
+                      'script must be run by a superuser';
+   END IF;
+END
+$$;
+
+
+--Create a temporary function to test if a role with the given name exists
+-- performs case-sensitive test for roleName;
+-- role names are intentionally not case folded at this time
+CREATE OR REPLACE FUNCTION pg_temp.existsRole(roleName VARCHAR(63))
+RETURNS BOOLEAN AS
+$$
+   SELECT 1 = (SELECT COUNT(*) FROM pg_catalog.pg_roles WHERE rolname = $1);
+$$ LANGUAGE sql;
+
+--Create app-specific roles and users
+-- also give the Gradebook role the ability to create roles and databases, as
+-- well as the ability to manipulate backends: cancel query, terminate, etc.
+DO
+$$
+BEGIN
+
+   --create role Gradebook if necessary; give it the required rights
+   IF NOT pg_temp.existsRole('gradebook') THEN
+      CREATE ROLE Gradebook;
+   END IF;
+
+   ALTER ROLE Gradebook CREATEROLE CREATEDB;
+   GRANT pg_signal_backend TO Gradebook;
+
+
+   --create user GB_WebApp if necessary and make sure the user is a member of
+   --Gradebook role
+   -- a default password is assigned to the user: user/admin should change it
+   IF NOT pg_temp.existsRole('gb_webapp') THEN
+      CREATE USER GB_WebApp WITH PASSWORD 'dassl2017';
+   END IF;
+
+   --make user GB_WebApp a member of role Gradebook
+   -- a temporary solution until the role Gradebook is made owner of all
+   -- functions, and the functions are made to execute in the context of their
+   -- owner
+   GRANT Gradebook TO GB_WebApp;
+
+END
+$$;
+
+
+COMMIT;

--- a/tests/data/Attendance/importAttendance.psql
+++ b/tests/data/Attendance/importAttendance.psql
@@ -11,7 +11,7 @@
 
 
 --Due to the use of the \COPY meta-command, this script needs to be run using the
--- psql command line tool provided with most PostgreSQL installations. The current 
+-- psql command line tool provided with most PostgreSQL installations. The current
 -- working directory needs be the same as this script's location.
 
 --This script should only be run after importing all sample Roster data provided
@@ -51,8 +51,8 @@ $$
    FROM pg_temp.AttendanceStaging
    WHERE Code IS NOT NULL
    ON CONFLICT (Status) DO NOTHING;
-   
-   --Match student from each entry in sample data with their corresponsing entry in 
+
+   --Match student from each entry in sample data with their corresponsing entry in
    -- the Student table by joining on a match of the 3 name parts. MName can be NULL
    -- and rows with NULL as the attendance code are interpreted as Present and not
    -- imported. (See behavior of Gradebook.getAttendance() in /src/db/getAttendance.sql)
@@ -63,12 +63,13 @@ $$
         COALESCE(a.MName, '') = COALESCE(s.MName, '')
    WHERE a.Code IS NOT NULL
    ON CONFLICT DO NOTHING;
-$$ LANGUAGE sql;
+$$ LANGUAGE sql
+   RETURNS NULL ON NULL INPUT; --no need to run the function if sectionID is NULL
 
 
 --Import data from files to staging table and call import function for each section
 \COPY pg_temp.AttendanceStaging FROM '2017SpringCS110-05Attendance.csv' WITH csv HEADER
-SELECT pg_temp.importAttendance(Gradebook.getSectionID(2017, 0, 'CS110', '05'));
+SELECT pg_temp.importAttendance(Gradebook.getSectionID(2017, 0, 'CS110', '5'));
 TRUNCATE pg_temp.AttendanceStaging;
 
 \COPY pg_temp.AttendanceStaging FROM '2017SpringCS110-72Attendance.csv' WITH csv HEADER


### PR DESCRIPTION
The commits in this PR significantly enhance (I believe) the procedure and scripts to set up the application's data layer.

Here is a summary of the changes:
- Added new script `prepareServer.sql` to create app-specific role `gradebook` and app-specific user `gb_webapp`. This script is modeled after its namesake in ClassDB.
- Added new script `initializeDB.sql` to set permissions for app-specific role and user. This script is modeled after its namesake in ClassDB, but is also quite different in its handling of permissions.
   - Takes away pretty much all privileges from `PUBLIC` and arranges for the app-specific role to be able to pretty much do anything in the database though we don't have ownership
- Removed Gradebook schema creation from `createTables.sql`, because `initializeDB.sql` now does that work
- Added call to `initializeDB.sql` in `prepareDB.psql`
- Revamped README to incorporate the new scripts. This file has changed quite a bit.

Here are some noteworthy things:
- The app-specific role name and user name are not quoted in the script (intentionally), but psql seems to fold case the -U option it receives. So, you must use `gb_webapp` to log in using psql
- Oddly enough even our web client needs to send `gb_webapp` for login to succeed. So, it is probably something I am doing that requires the use of lower case. Unfortunately, I do not have the time to investigate, and it is not really necessary to fix it now. However, **the web client should probably change the default value of DB user field to lower case**.
- The app-specific user is given a default password in the script `prepareServer.sql`. The admin can change it.
- The installation scripts cause various notices to display. However, this is a previously existing issue: no new display of notice is caused by these commits.