### PR TITLE
Web Client: Change DB and DB Username defaults to lowercase

### DIFF
--- a/src/webapp/client/index.html
+++ b/src/webapp/client/index.html
@@ -112,11 +112,11 @@ Currently, only attendance information is served
 				<label for="port">Port</label>
 			</div>
 			<div class="input-field col s12 m6 l3">
-				<input id="database" type="text" value="Gradebook"/>
+				<input id="database" type="text" value="gradebook"/>
 				<label for="database">Database</label>
 			</div>
 			<div class="input-field col s12 m6 l3">
-				<input id="user" type="text" value="GB_WebApp"/>
+				<input id="user" type="text" value="gb_webapp"/>
 				<label for="user">DB Username</label>
 			</div>
 			</div>


### PR DESCRIPTION
This PR makes the default values for the Database and DB Username fields on the login page of the web client lowercase. This is necessary because the values are not folded to lowercase before being used to login.

"Gradebook" -> "gradebook"

"GB_WebApp" -> "gb_webapp"

See discussion in PR #61 for more information.