### PR TITLE
Fix start position of end-date

### DIFF
--- a/src/db/importCourseSchedule/prepareCourseScheduleImport.sql
+++ b/src/db/importCourseSchedule/prepareCourseScheduleImport.sql
@@ -106,7 +106,7 @@ BEGIN
    WITH termDates AS
    ( --make a list of the start and end dates for each class
       SELECT substring(date FROM 1 FOR 5) sDate,
-             substring(date FROM 6 FOR 5) eDate
+             substring(date FROM 7 FOR 5) eDate
       FROM pg_temp.CourseScheduleStaging
    )
    --Select the extreme start and end dates from TermDates


### PR DESCRIPTION
An off-by-one error caused issues when importing OpenClose data. For more information, see Issue #66

See issue #68 before testing this PR. (When testing Gradebook, OpenClose data from Spring 2017 should be imported, not Spring 2015).

Due to logistical reasons, @jrm86 and @KevinKelly25, who are two DASSL members, but who are not collaborators of the repository, are also being requested to review (they cannot be added as reviewers in the sidebar). A review from either of the three DASSL members will be sufficient to merge, regardless of write access.

Closes #66