### PR TITLE
Fix filename in installation verification

### DIFF
--- a/src/db/README.md
+++ b/src/db/README.md
@@ -115,7 +115,7 @@ the user `gb_webapp`. It is sufficient to complete only the first step shown,
 but it is recommended that all steps be performed in the sequence shown. A
 verification step is considered successful if it completes without any error.
 
-1. Import the course schedule in the file `/tests/data/OpenClose/2015SpringOpenClose.csv`
+1. Import the course schedule in the file `/tests/data/OpenClose/2017SpringOpenClose.csv`
 
 2. Assign e-mail addresses to instructors: run the script `/tests/data/InstructorEmail/addEmailByInstructorName.sql`
 


### PR DESCRIPTION
The correct course schedule to import is `2017SpringOpenClose.csv` not `2015SpringOpenClose.csv`. See Issue #68 for more information.

Due to logistical reasons, @jrm86 and @KevinKelly25, who are two DASSL members, but who are not collaborators of the repository, are also being requested to review (they cannot be added as reviewers in the sidebar). A review from either of the three DASSL members will be sufficient to merge, regardless of write access.

Closes #68 