### PR TITLE
Update gradebookServer.js to close db connection on error

### DIFF
--- a/src/webapp/gradebookServer.js
+++ b/src/webapp/gradebookServer.js
@@ -70,12 +70,14 @@ function executeQuery(response, config, queryText, queryParams, queryCallback) {
    var client = new pg.Client(config); //Connect to pg instance
    client.connect(function(err) {
       if(err) { //If a connection error happens, 500
+         client.end(); //Close the connection
          response.status(500).send('500 - Database connection error');
          console.log(err);
       }
       else { //Try and execute the query
          client.query(queryText, queryParams, function (err, result) {
             if(err) { //If the query returns an error, 500
+               client.end(); //Close the connection
                response.status(500).send('500 - Query execution error');
                console.log(err);
             }


### PR DESCRIPTION
I have included two additional `client.end()` statements in the `executeQuery` function. These statements close the connection to the database when there is an error thrown by a sent query. This allows for multiple errors to be thrown without a buildup of unclosed connections, which might exceed the connection limit imposed by certain database applications, such as ClassDB.

I included these statements before other statements directly after the error is thrown as the connection is no longer needed at that point as far as I can tell, and there is no reason to keep it open until after the error logging is complete.

Edit: Closes #76 